### PR TITLE
Disable Mouse while riding & Looking around only while right mouse is pressed

### DIFF
--- a/CoasterCam/MouseLookAround.cs
+++ b/CoasterCam/MouseLookAround.cs
@@ -22,6 +22,12 @@ namespace CoasterCam
 
         void Update()
         {
+            // only move if right mouse button is pressed
+            if(!Input.GetMouseButton(1))
+            {
+                return;
+            }
+
             if (Axes == RotationAxes.MouseXAndY)
             {
                 float rotationX = transform.localEulerAngles.y + Input.GetAxis("Mouse X") * _sensitivityX;

--- a/CoasterCam/MouseLookAround.cs
+++ b/CoasterCam/MouseLookAround.cs
@@ -25,7 +25,7 @@ namespace CoasterCam
             if (Axes == RotationAxes.MouseXAndY)
             {
                 float rotationX = transform.localEulerAngles.y + Input.GetAxis("Mouse X") * _sensitivityX;
-                
+
                 _rotationY += Input.GetAxis("Mouse Y") * _sensitivityY;
                 _rotationY = Mathf.Clamp(_rotationY, _minimumY, _maximumY);
 
@@ -43,5 +43,26 @@ namespace CoasterCam
                 transform.localEulerAngles = new Vector3(-_rotationY, transform.localEulerAngles.y, 0);
             }
         }
+
+        private IMouseTool _disableMouseTool;
+
+        void OnEnable()
+        {
+            _disableMouseTool = new DisableMouseInteractionMouseTool();
+            GameController.Instance.enableMouseTool(_disableMouseTool);
+        }
+        void OnDisable()
+        {
+            GameController.Instance.removeMouseTool(_disableMouseTool);
+        }
+        private class DisableMouseInteractionMouseTool : AbstractMouseTool
+        {
+            public override bool canEscapeMouseTool() => false;
+
+            public override GameController.GameFeature getDisallowedFeatures()
+                =>  GameController.GameFeature.Picking
+                    | GameController.GameFeature.Delete
+                    | GameController.GameFeature.DragDelete;
+    }
     }
 }


### PR DESCRIPTION
Even if the mouse gets disabled while riding it can still select (left click) or delete (right click) stuff. 
5970874  adds a simple MouseTool that basically does nothing and therefore prevents such accidental clicks.

Directly binding camera to mouse movement result in a very unstable viewing position. aa751e2 prevents that and instead only moves the camera while the right mouse button is pressed.

