### PR TITLE
settings: add mod setting to adjust camera smoothing

### DIFF
--- a/CoasterCam/CoasterCam.cs
+++ b/CoasterCam/CoasterCam.cs
@@ -43,6 +43,8 @@ namespace CoasterCam
 
         private int _seatIndex;
 
+        public float SmoothingAmount { get; set; } = ModSettings.DefaultSmoothing;
+
 
         private List<Tuple<string, Vector3, Vector3>> _views = new List<Tuple<string, Vector3, Vector3>>()
         {
@@ -177,8 +179,9 @@ namespace CoasterCam
                 if (_coaster != null)
                 {
                     var point1 = _coaster.Track.getPoint(_coaster.Track.trains[0].currentTrackPosition);
-                    var lookAtPosition = _coaster.Track.trains[0].currentTrackPosition + 1.5f +
-                                         _coaster.Track.trains[0].velocity / 30;
+                    float lookAhead = Mathf.Lerp(0f, 1.5f, SmoothingAmount); // look further ahead when smoothing
+                    float velocityOffset = (_coaster.Track.trains[0].velocity / 30) * SmoothingAmount; // faster -> reach point faster
+                    var lookAtPosition = _coaster.Track.trains[0].currentTrackPosition + lookAhead + velocityOffset;
                     var point2 = _coaster.Track.getPoint(lookAtPosition);
                     var oldRot = _head.transform.localEulerAngles;
 

--- a/CoasterCam/Main.cs
+++ b/CoasterCam/Main.cs
@@ -10,13 +10,14 @@ using Object = UnityEngine.Object;
 
 namespace CoasterCam
 {
-    public class Main : AbstractMod
-  {
+    public class Main : AbstractMod, IModSettings
+    {
         private static GameObject go;
+        private ModSettings _settings;
 
         public override string getName() => "CoasterCam";
         public override string getDescription() => "Camera for riding coasters";
-        public override string getVersionNumber() => "1.0.1";
+        public override string getVersionNumber() => "1.0.2";
         public override string getIdentifier() => "H-POPS@CoasterCam";
         public override bool isMultiplayerModeCompatible() => true;
         public override bool isRequiredByAllPlayersInMultiplayerMode() => false;
@@ -31,6 +32,9 @@ namespace CoasterCam
         {
             go = new GameObject(getIdentifier());
             go.AddComponent<CoasterCam>();
+
+            _settings = new ModSettings();
+            _settings.LoadSettings();
 
             try
             {
@@ -68,6 +72,29 @@ namespace CoasterCam
         public override void onDisabled()
         {
             Object.Destroy(go);
+        }
+
+        public void onSettingsOpened()
+        {
+            _settings = new ModSettings();
+        }
+
+        public void onSettingsClosed()
+        {
+            _settings.Save();
+        }
+
+        public void onDrawSettingsUI()
+        {
+            GUILayout.Label("Camera Smoothing");
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Off", GUILayout.Width(25));
+            float newSmoothing = GUILayout.HorizontalSlider(_settings.SmoothingAmount, 0f, 1.0f);
+            GUILayout.Label("Max", GUILayout.Width(30));
+            GUILayout.EndHorizontal();
+            GUILayout.Label("Value: " + newSmoothing.ToString("F2"));
+            if (newSmoothing != _settings.SmoothingAmount)
+                _settings.SmoothingAmount = newSmoothing;
         }
 
         private void SetupKeyBinding()

--- a/CoasterCam/ModSettings.cs
+++ b/CoasterCam/ModSettings.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+namespace CoasterCam
+{
+    public class ModSettings
+    {
+        private const string SmoothingKey = "CoasterCam_SmoothingAmount";
+        public const float DefaultSmoothing = 0.15f;
+
+        public float SmoothingAmount
+        {
+            get { return PlayerPrefs.GetFloat(SmoothingKey, DefaultSmoothing); }
+            set
+            {
+                PlayerPrefs.SetFloat(SmoothingKey, Mathf.Clamp01(value));
+                if (CoasterCam.Instance != null)
+                    CoasterCam.Instance.SmoothingAmount = value;
+            }
+        }
+
+        public void LoadSettings()
+        {
+            if (CoasterCam.Instance != null)
+                CoasterCam.Instance.SmoothingAmount = SmoothingAmount;
+        }
+
+        public void Save()
+        {
+            PlayerPrefs.Save();
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a new settings handle where the user can adjust the amount of smoothing.

The setting can be adjusted from [0->1] where:
0: no smoothing (completely rigid cam following the track stricly) 1: the amount of smoothing currently used

I've set the default smoothing to 0.15 as the current amount of smoothing is quite inconsistent and exaggerated. Also quite a few people have commented on this on steam workshop.

Now the user can control how much they want :)